### PR TITLE
Updated `history` to actually work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ Type: `Object`
 A dictionary of customizable options
 
 - `interval` - Set the interval for the price changes, e.g. `1m`, `1d`, `5d`, `1mo`, `1y`.
-- `start` - Set the start timestamp string, as supported by [moment.js](https://momentjs.com/docs/#/parsing/string/), e.g. `'2013-02-08 09:30:26.123'`.
-- `end` - Set the start timestamp string, as supported by [moment.js](https://momentjs.com/docs/#/parsing/string/), e.g. `'2013-02-09 16:30:26.123'`.
-
+- `range` - Set the range of dates to include in the output, value values are: `1d`, `5d`, `1mo`, `3mo`, `6mo`, `1y`, `2y`, `5y`, `10y`, `ytd`, `max`
 ## License
 
 MIT © [Vu Tran](https://github.com/vutran/)

--- a/index.js
+++ b/index.js
@@ -50,24 +50,16 @@ const lookup = (symbol) => new Promise((resolve, reject) => {
         .catch(reject);
 });
 
-const history = (symbol, options) => new Promise((resolve, reject) => {
-    let interval = '1m';
-    let start = moment().utc().hour(14).minute(30).second(0).millisecond(0).subtract(1, 'day');
-    let end = start.clone().hour(21).minute(0).second(0).millisecond(0);
+const history = (symbol, args) => new Promise((resolve, reject) => {
+    let options = {
+        range: '1y',
+        interval: '1m',
+        ...args
+    };
+        
 
-    if (options) {
-        interval = options.interval || interval;
-        start = options.start ? moment(options.start) : start;
-        end = options.end ? moment(options.end) : end;
 
-        if (options.interval === '5d') {
-            interval = '5m';
-            start.subtract(6, 'day');
-            end.set(start);
-        }
-    }
-
-    getJson(`https://query2.finance.yahoo.com/v7/finance/chart/${symbol}?period2=${end.unix()}&period1=${start.unix()}&interval=${interval}&indicators=quote&includeTimestamps=true&includePrePost=true&events=div%7Csplit%7Cearn`)
+    getJson(`https://query2.finance.yahoo.com/v7/finance/chart/${symbol}?range=${options.range}&interval=${options.interval}&indicators=quote&includeTimestamps=true&includePrePost=true&events=div%7Csplit%7Cearn`)
         .then((response) => {
             const quote = response.chart.result[0].indicators.quote[0];
             const meta = response.chart.result[0].meta;


### PR DESCRIPTION
    Changed `history` call to use new `range` argument instead of manually
    calculating `start` and `end` periods. This is a much simpler interface
    and has the added benefit of actually working.

    The `history` function now accepts an options object that can contain up
    to two keys:
    `range` and `interval`.
    Range has the following signature:
    validRanges:
    [ '1d',
      '5d',
      '1mo',
      '3mo',
      '6mo',
      '1y',
      '2y',
      '5y',
      '10y',
      'ytd',
      'max'
    ]
